### PR TITLE
Add minimal Github Action CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+    - run: nix -L flake check


### PR DESCRIPTION
Previously my private Hercules CI runners ran the CI, but they can't run on the Cyberus org. For simplicity, switch to Github Actions for now.